### PR TITLE
Add inspect sub-command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,12 +287,12 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "stellar-contract-env-host",
+ "thiserror",
 ]
 
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=52488e41#52488e413b84c979e0b44b9754f2fd3ac22ad9a4"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -302,11 +302,11 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=52488e41#52488e413b84c979e0b44b9754f2fd3ac22ad9a4"
 dependencies = [
  "im-rc",
  "num-bigint",
  "num-rational",
+ "parity-wasm",
  "static_assertions",
  "stellar-contract-env-common",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=b9be0d3a#b9be0d3a73e0f79ca48ed6a507c2eb8d926c44ca"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -302,6 +303,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=b9be0d3a#b9be0d3a73e0f79ca48ed6a507c2eb8d926c44ca"
 dependencies = [
  "im-rc",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "52488e41", features = ["vm"] }
-# stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
+#stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "b17ef082", features = ["vm"] }
+stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
 clap = { version = "3.1.18", features = ["derive", "env"] }
+thiserror = "1.0.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-#stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "b17ef082", features = ["vm"] }
-stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "b9be0d3a", features = ["vm"] }
+# stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 thiserror = "1.0.31"

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -23,9 +23,14 @@ impl Inspect {
         let contents = fs::read(&self.file)?;
         let h = Host::default();
         let vm = Vm::new(&h, contractid::ZERO, &contents)?;
-        println!("Exports:");
+        println!("Functions:");
         for f in vm.functions() {
-            println!("- {}({})", f.name, "arg,".repeat(f.arity));
+            println!(
+                " • {} ({}) -> ({})",
+                f.name,
+                vec!["val"; f.param_count].join(", "),
+                vec!["res"; f.result_count].join(", ")
+            );
         }
         Ok(())
     }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,0 +1,32 @@
+use clap::Parser;
+use std::{fmt::Debug, fs, io};
+use stellar_contract_env_host::{Host, HostError, Vm};
+
+use crate::contractid;
+
+#[derive(Parser, Debug)]
+pub struct Inspect {
+    #[clap(long, parse(from_os_str))]
+    file: std::path::PathBuf,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("io")]
+    Io(#[from] io::Error),
+    #[error("host")]
+    Host(#[from] HostError),
+}
+
+impl Inspect {
+    pub fn run(&self) -> Result<(), Error> {
+        let contents = fs::read(&self.file)?;
+        let h = Host::default();
+        let vm = Vm::new(&h, contractid::ZERO, &contents)?;
+        println!("Exports:");
+        for f in vm.functions() {
+            println!("- {}({})", f.name, "arg,".repeat(f.arity));
+        }
+        Ok(())
+    }
+}

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt::Debug, fmt::Display, fs};
+use std::{fmt::Debug, fs, io};
 
 use clap::Parser;
 use stellar_contract_env_host::{
@@ -21,60 +21,16 @@ pub struct Invoke {
     args: Vec<String>,
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    Other(Box<dyn error::Error>),
-    StrVal(StrValError),
-    Xdr(XdrError),
-    Host(HostError),
-}
-
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::Other(e) => e.source(),
-            Self::StrVal(e) => e.source(),
-            Self::Xdr(e) => e.source(),
-            Self::Host(e) => e.source(),
-        }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invoke error: ")?;
-        match self {
-            Self::Other(e) => std::fmt::Display::fmt(&e, f)?,
-            Self::StrVal(e) => std::fmt::Display::fmt(&e, f)?,
-            Self::Xdr(e) => std::fmt::Display::fmt(&e, f)?,
-            Self::Host(e) => std::fmt::Display::fmt(&e, f)?,
-        };
-        Ok(())
-    }
-}
-
-impl From<Box<dyn error::Error>> for Error {
-    fn from(e: Box<dyn error::Error>) -> Self {
-        Self::Other(e)
-    }
-}
-
-impl From<StrValError> for Error {
-    fn from(e: StrValError) -> Self {
-        Self::StrVal(e)
-    }
-}
-
-impl From<XdrError> for Error {
-    fn from(e: XdrError) -> Self {
-        Self::Xdr(e)
-    }
-}
-
-impl From<HostError> for Error {
-    fn from(e: HostError) -> Self {
-        Self::Host(e)
-    }
+    #[error("io")]
+    Io(#[from] io::Error),
+    #[error("strval")]
+    StrVal(#[from] StrValError),
+    #[error("xdr")]
+    Xdr(#[from] XdrError),
+    #[error("host")]
+    Host(#[from] HostError),
 }
 
 impl Invoke {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
 use clap::{Parser, Subcommand};
+use thiserror::Error;
 
 mod contractid;
 mod strval;
+
+mod inspect;
+use inspect::Inspect;
 
 mod invoke;
 use invoke::Invoke;
@@ -15,15 +19,29 @@ struct Root {
 
 #[derive(Subcommand, Debug)]
 enum Cmd {
+    Inspect(Inspect),
     Invoke(Invoke),
+}
+
+#[derive(Error, Debug)]
+enum CmdError {
+    #[error("inspect")]
+    Inspect(#[from] inspect::Error),
+    #[error("invoke")]
+    Invoke(#[from] invoke::Error),
+}
+
+fn run(cmd: Cmd) -> Result<(), CmdError> {
+    match cmd {
+        Cmd::Inspect(inspect) => inspect.run()?,
+        Cmd::Invoke(invoke) => invoke.run()?,
+    };
+    Ok(())
 }
 
 fn main() {
     let root = Root::parse();
-    let res = match root.cmd {
-        Cmd::Invoke(args) => args.run(),
-    };
-    match res {
+    match run(root.cmd) {
         Ok(_) => println!("ok"),
         Err(e) => println!("error: {}", e),
     }


### PR DESCRIPTION
### What

Add inspect sub-command that displays information about the wasm file, initially just the wasm funcctions.

### Example

```
❯ stellar-contract-cli inspect --file target/wasm32-unknown-unknown/release/example_add_i64.wasm
Functions:
 • add (val, val) -> (res)
```

### Why

For developer interactions for understanding what is in a wasm file.

### Known limitations

This is just the start of functionality and other functionality can be added.