### PR TITLE
Remove 'ok' from output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,7 @@ fn run(cmd: Cmd) -> Result<(), CmdError> {
 
 fn main() {
     let root = Root::parse();
-    match run(root.cmd) {
-        Ok(_) => println!("ok"),
-        Err(e) => println!("error: {}", e),
+    if let Err(e) = run(root.cmd) {
+        println!("error: {}", e);
     }
 }


### PR DESCRIPTION
### What

Remove 'ok' from output when command succeeds.

### Why

Frivolous.

### Known limitations

[TODO or N/A]
