### PR TITLE
Add contract spec to inspect subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stellar-contract-cli"
 version = "0.0.0"
 dependencies = [
+ "base64",
  "clap",
  "stellar-contract-env-host",
  "thiserror",
@@ -293,7 +294,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=b9be0d3a#b9be0d3a73e0f79ca48ed6a507c2eb8d926c44ca"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c2b25532#c2b25532aa3fc0e6d2f1f91c5fe6ae260d215c56"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -303,7 +304,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=b9be0d3a#b9be0d3a73e0f79ca48ed6a507c2eb8d926c44ca"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=c2b25532#c2b25532aa3fc0e6d2f1f91c5fe6ae260d215c56"
 dependencies = [
  "im-rc",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "b9be0d3a", features = ["vm"] }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "c2b25532", features = ["vm"] }
 # stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
 clap = { version = "3.1.18", features = ["derive", "env"] }
+base64 = "0.13.0"
 thiserror = "1.0.31"

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -23,6 +23,7 @@ impl Inspect {
         let contents = fs::read(&self.file)?;
         let h = Host::default();
         let vm = Vm::new(&h, contractid::ZERO, &contents)?;
+        println!("File: {}", self.file.to_string_lossy());
         println!("Functions:");
         for f in vm.functions() {
             println!(
@@ -31,6 +32,11 @@ impl Inspect {
                 vec!["val"; f.param_count].join(", "),
                 vec!["res"; f.result_count].join(", ")
             );
+        }
+        if let Some(spec) = vm.custom_section("contractspecv0") {
+            println!("Contract Spec: {}", base64::encode(spec));
+        } else {
+            println!("Contract Spec: None");
         }
         Ok(())
     }


### PR DESCRIPTION
### What

Add contract spec to inspect subcommand.

### Why

For debugging the contract spec in contracts. Eventually it can be pretty formatted.

### Known limitations

[TODO or N/A]
