### PR TITLE
Print full raw error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,6 @@ fn run(cmd: Cmd) -> Result<(), CmdError> {
 fn main() {
     let root = Root::parse();
     if let Err(e) = run(root.cmd) {
-        println!("error: {}", e);
+        println!("error: {:?}", e);
     }
 }


### PR DESCRIPTION
### What

Print full raw error.

### Why

The errors story for the CLI is not particularly organized and by printing the error we at least get full visibility into what error is happening at this point, even if the output isn't pretty.

### Known limitations

Should really circle back on making the error output nicer. At least making it just a human readable well formed string.
