### PR TITLE
Add install target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ all: check build test
 
 export RUSTFLAGS=-Dwarnings -Dclippy::all -Dclippy::pedantic
 
+install:
+	cargo install --path .
+
 test:
 	cargo test
 


### PR DESCRIPTION
### What

Add install target to Makefile.

### Why

For convenience while developing with other things, it is convenient to be able to make install.

### Known limitations

[TODO or N/A]
