### PR TITLE
Decode contract spec in inspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "clap"
 version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +104,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "im-rc"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -114,10 +143,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
+name = "memory_units"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "proc-macro-error"
@@ -162,12 +251,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stellar-contract-cli"
 version = "0.0.0"
 dependencies = [
  "base64",
  "clap",
+ "stellar-contract-env-host",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec)",
  "thiserror",
+]
+
+[[package]]
+name = "stellar-contract-env-common"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=3e1b8fd4#3e1b8fd4a7f0630e41955e9a41d35e85791505eb"
+dependencies = [
+ "static_assertions",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=9305173c)",
+ "wasmi",
+]
+
+[[package]]
+name = "stellar-contract-env-host"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=3e1b8fd4#3e1b8fd4a7f0630e41955e9a41d35e85791505eb"
+dependencies = [
+ "im-rc",
+ "num-bigint",
+ "num-rational",
+ "parity-wasm",
+ "static_assertions",
+ "stellar-contract-env-common",
+ "thiserror",
+ "wasmi",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#70fa23e1ba306ba323d0895c565e318880660a54"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=9305173c#9305173ccaa4aac78fe33ba74e09ec32c9bbb908"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -223,6 +386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +402,30 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasmi"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a3cb58f98e4d6c944af18c2c9002f22d0b928dfbb8b6c2b7d78a8573a5216bf"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "memory_units",
+ "num-rational",
+ "num-traits",
+ "parity-wasm",
+ "wasmi-validation",
+]
+
+[[package]]
+name = "wasmi-validation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
+dependencies = [
+ "parity-wasm",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#2070b51d8ff5a2b4e2d048f4fb125cdebccce1f4"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#9ed7ee499114c803b20aae207befa4bd8c693b18"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#8830729932a04d67a26c8a8f15fd5730adf99bed"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#30a10552098481ed1c20d4d379335da27de26e46"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#30a10552098481ed1c20d4d379335da27de26e46"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#3558eb03cf4b1ca60cac50e862b74449155a6378"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#9a236b0d4f0c4ade7ec6e5be8821c2bc164a0bcb"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#2070b51d8ff5a2b4e2d048f4fb125cdebccce1f4"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#3558eb03cf4b1ca60cac50e862b74449155a6378"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#026329f72e8d660ef5ef5539085a3e82bd8dbf57"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#70fa23e1ba306ba323d0895c565e318880660a54"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#8830729932a04d67a26c8a8f15fd5730adf99bed"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#026329f72e8d660ef5ef5539085a3e82bd8dbf57"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#9a236b0d4f0c4ade7ec6e5be8821c2bc164a0bcb"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,17 +295,17 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=3e1b8fd4#3e1b8fd4a7f0630e41955e9a41d35e85791505eb"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=b5b0304d#b5b0304d471a42e933c9717da0ed24f2e896483c"
 dependencies = [
  "static_assertions",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=9305173c)",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=462efdd1)",
  "wasmi",
 ]
 
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=3e1b8fd4#3e1b8fd4a7f0630e41955e9a41d35e85791505eb"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=b5b0304d#b5b0304d471a42e933c9717da0ed24f2e896483c"
 dependencies = [
  "im-rc",
  "num-bigint",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=9305173c#9305173ccaa4aac78fe33ba74e09ec32c9bbb908"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=462efdd1#462efdd1a53dd244529bb99112cf2a33dc5d9e28"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,24 +508,23 @@ dependencies = [
  "base64",
  "clap",
  "stellar-contract-env-host",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec)",
  "thiserror",
 ]
 
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=5e6bd28f#5e6bd28f2e153c5a144ede013baefa4d0e34202e"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=42fc83ac#42fc83acacc8d155a92d3b3aca8d917296c58704"
 dependencies = [
  "static_assertions",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=cca41237)",
+ "stellar-xdr",
  "wasmi",
 ]
 
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=5e6bd28f#5e6bd28f2e153c5a144ede013baefa4d0e34202e"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=42fc83ac#42fc83acacc8d155a92d3b3aca8d917296c58704"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -543,15 +542,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#5e80a0daae8d48293273affd18b549afb88367a4"
-dependencies = [
- "base64",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=cca41237#cca412374f098c9ff3960032f5a9117c1cad183b"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=277d41c3#277d41c3c1e1ebd5ad91ff3c190cdb1fe42954c7"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#dad2a6beecb7cab35b0cb77ac932b49bf7b7d7ef"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=add-spec#5e80a0daae8d48293273affd18b549afb88367a4"
 dependencies = [
  "base64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", branch = "add-spec", features = ["next", "std"] }
 stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "3e1b8fd4", features = ["vm"] }
 # stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
 clap = { version = "3.1.18", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", branch = "add-spec", features = ["next", "std"] }
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "3e1b8fd4", features = ["vm"] }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "b5b0304d", features = ["vm"] }
 # stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", branch = "add-spec", features = ["next", "std"] }
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "5e6bd28f", features = ["vm"] }
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "42fc83ac", features = ["vm"] }
 # stellar-contract-env-host = { path = "../rs-stellar-contract-env/stellar-contract-env-host", features = ["vm"] }
 clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -50,7 +50,13 @@ impl Inspect {
                         ),
                         SpecEntry::Udt(_) => todo!(),
                     },
-                    Err(e) => println!("error: {}", e),
+                    Err(stellar_xdr::Error::IO(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                        // TODO: Distinguish between EOF and EOF with partial fill.
+                        break;
+                    }
+                    Err(e) => {
+                        println!("error: {}", e);
+                    }
                 }
             }
         } else {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use std::{fmt::Debug, fs, io, io::Cursor, str::Utf8Error};
-use stellar_contract_env_host::{Host, HostError, Vm};
-use stellar_xdr::{ReadXdr, SpecEntry, SpecEntryFunction, SpecEntryUdt};
+use stellar_contract_env_host::{
+    xdr::{self, ReadXdr, SpecEntry, SpecEntryFunction, SpecEntryUdt},
+    Host, HostError, Vm,
+};
 
 #[derive(Parser, Debug)]
 pub struct Inspect {
@@ -12,7 +14,7 @@ pub struct Inspect {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("xdr")]
-    Xdr(#[from] stellar_xdr::Error),
+    Xdr(#[from] xdr::Error),
     #[error("io")]
     Io(#[from] io::Error),
     #[error("host")]

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -40,8 +40,7 @@ impl Inspect {
             println!("Contract Spec: {}", base64::encode(spec));
             let mut cursor = Cursor::new(spec);
             for spec_entry in SpecEntry::read_xdr_iter(&mut cursor) {
-                let spec_entry = spec_entry?;
-                match spec_entry {
+                match spec_entry? {
                     SpecEntry::Function(SpecEntryFunction::V0(f)) => println!(
                         " • Function: {} ({:?}) -> ({:?})",
                         f.name.to_string()?,

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -39,15 +39,18 @@ impl Inspect {
         if let Some(spec) = vm.custom_section("contractspecv0") {
             println!("Contract Spec: {}", base64::encode(spec));
             let mut cursor = Cursor::new(spec);
-            while let Ok(spec_entry) = SpecEntry::read_xdr(&mut cursor) {
-                match spec_entry {
-                    SpecEntry::Function(SpecEntryFunction::V0(f)) => println!(
-                        " • Function: {} ({:?}) -> ({:?})",
-                        std::str::from_utf8(f.name.as_slice())?,
-                        f.input_types.as_slice(),
-                        f.output_types.as_slice(),
-                    ),
-                    SpecEntry::Udt(_) => todo!(),
+            loop {
+                match SpecEntry::read_xdr(&mut cursor) {
+                    Ok(spec_entry) => match spec_entry {
+                        SpecEntry::Function(SpecEntryFunction::V0(f)) => println!(
+                            " • Function: {} ({:?}) -> ({:?})",
+                            f.name.to_string()?,
+                            f.input_types.as_slice(),
+                            f.output_types.as_slice(),
+                        ),
+                        SpecEntry::Udt(_) => todo!(),
+                    },
+                    Err(e) => println!("error: {}", e),
                 }
             }
         } else {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -47,7 +47,7 @@ impl Inspect {
                         f.input_types.as_slice(),
                         f.output_types.as_slice(),
                     ),
-                    SpecEntry::Type(_) => todo!(),
+                    SpecEntry::Udt(_) => todo!(),
                 }
             }
         } else {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::{fmt::Debug, fs, io, io::Cursor, str::Utf8Error};
 use stellar_contract_env_host::{Host, HostError, Vm};
-use stellar_xdr::{ReadXdr, SpecEntry, SpecEntryFunction};
+use stellar_xdr::{ReadXdr, SpecEntry, SpecEntryFunction, SpecEntryUdt};
 
 #[derive(Parser, Debug)]
 pub struct Inspect {
@@ -47,7 +47,9 @@ impl Inspect {
                         f.input_types.as_slice(),
                         f.output_types.as_slice(),
                     ),
-                    SpecEntry::Udt(_) => todo!(),
+                    SpecEntry::Udt(SpecEntryUdt::V0(udt)) => {
+                        println!(" • User-Defined Type: {:?}", udt);
+                    }
                 }
             }
         } else {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -39,24 +39,16 @@ impl Inspect {
         if let Some(spec) = vm.custom_section("contractspecv0") {
             println!("Contract Spec: {}", base64::encode(spec));
             let mut cursor = Cursor::new(spec);
-            loop {
-                match SpecEntry::read_xdr(&mut cursor) {
-                    Ok(spec_entry) => match spec_entry {
-                        SpecEntry::Function(SpecEntryFunction::V0(f)) => println!(
-                            " • Function: {} ({:?}) -> ({:?})",
-                            f.name.to_string()?,
-                            f.input_types.as_slice(),
-                            f.output_types.as_slice(),
-                        ),
-                        SpecEntry::Udt(_) => todo!(),
-                    },
-                    Err(stellar_xdr::Error::IO(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                        // TODO: Distinguish between EOF and EOF with partial fill.
-                        break;
-                    }
-                    Err(e) => {
-                        println!("error: {}", e);
-                    }
+            for spec_entry in SpecEntry::read_xdr_iter(&mut cursor) {
+                let spec_entry = spec_entry?;
+                match spec_entry {
+                    SpecEntry::Function(SpecEntryFunction::V0(f)) => println!(
+                        " • Function: {} ({:?}) -> ({:?})",
+                        f.name.to_string()?,
+                        f.input_types.as_slice(),
+                        f.output_types.as_slice(),
+                    ),
+                    SpecEntry::Udt(_) => todo!(),
                 }
             }
         } else {

--- a/src/strval.rs
+++ b/src/strval.rs
@@ -87,6 +87,9 @@ pub fn to_string(_h: &Host, v: ScVal) -> String {
             ScObject::U64(v) => format!("u64:{}", v),
             ScObject::I64(v) => format!("i64:{}", v),
             ScObject::Binary(_) => todo!(),
+            ScObject::BigInt(_) => todo!(),
+            ScObject::Hash(_) => todo!(),
+            ScObject::PublicKey(_) => todo!(),
         },
     }
 }


### PR DESCRIPTION
### What

Decode contract spec XDR in WASM files.

### Why

As a first step so that the CLI can display the contract spec in a human readable format to the user. Near term the same logic will be used for generating client code.

Close https://github.com/stellar/stellar-contract-cli/issues/6
Dependent on https://github.com/stellar/rs-stellar-xdr/pull/76
Related to https://github.com/stellar/rs-stellar-contract-sdk/pull/140

### Known limitations

[TODO or N/A]
