### PR TITLE
Use the toolchain file in GitHub CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
+    - run: rustup update
     - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
 
   build:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
+    - run: rustup update
     - run: rustup target add ${{ matrix.target }}
     - run: cargo clippy --all-targets --profile ${{ matrix.profile }} --target ${{ matrix.target }}
 
@@ -49,6 +49,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
+    - run: rustup update
     - run: rustup target add ${{ matrix.target }}
     - run: cargo test --profile ${{ matrix.profile }} --target ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,9 @@ check:
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+targets = []
+components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What

Use the toolchain file in GitHub Actions.

### Why

There's no reason to respecify values that are included already in the toolchain file since the action will load them from there.

### Known limitations

[TODO or N/A]
