### PR TITLE
Output env interface version in inspect sub-command

### DIFF
--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -44,7 +44,7 @@ impl Inspect {
             for env_meta_entry in ScEnvMetaEntry::read_xdr_iter(&mut cursor) {
                 match env_meta_entry? {
                     ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(v) => {
-                        println!(" • Interface Version: {}", v,)
+                        println!(" • Interface Version: {}", v)
                     }
                 }
             }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::{fmt::Debug, fs, io, io::Cursor, str::Utf8Error};
 use stellar_contract_env_host::{
-    xdr::{self, ReadXdr, ScSpecEntry},
+    xdr::{self, ReadXdr, ScSpecEntry, ScEnvMetaEntry},
     Host, HostError, Vm,
 };
 
@@ -37,6 +37,20 @@ impl Inspect {
                 vec!["val"; f.param_count].join(", "),
                 vec!["res"; f.result_count].join(", ")
             );
+        }
+        if let Some(env_meta) = vm.custom_section("contractenvmetav0") {
+            println!("Env Meta: {}", base64::encode(env_meta));
+            let mut cursor = Cursor::new(env_meta);
+            for env_meta_entry in ScEnvMetaEntry::read_xdr_iter(&mut cursor) {
+                match env_meta_entry? {
+                    ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(v) => println!(
+                        " • Interface Version: {}",
+                        v,
+                    ),
+                }
+            }
+        } else {
+            println!("Contract Spec: None");
         }
         if let Some(spec) = vm.custom_section("contractspecv0") {
             println!("Contract Spec: {}", base64::encode(spec));

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -44,7 +44,7 @@ impl Inspect {
             for env_meta_entry in ScEnvMetaEntry::read_xdr_iter(&mut cursor) {
                 match env_meta_entry? {
                     ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(v) => {
-                        println!(" • Interface Version: {}", v)
+                        println!(" • Interface Version: {}", v);
                     }
                 }
             }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::{fmt::Debug, fs, io, io::Cursor, str::Utf8Error};
 use stellar_contract_env_host::{
-    xdr::{self, ReadXdr, ScSpecEntry, ScEnvMetaEntry},
+    xdr::{self, ReadXdr, ScEnvMetaEntry, ScSpecEntry},
     Host, HostError, Vm,
 };
 
@@ -43,10 +43,9 @@ impl Inspect {
             let mut cursor = Cursor::new(env_meta);
             for env_meta_entry in ScEnvMetaEntry::read_xdr_iter(&mut cursor) {
                 match env_meta_entry? {
-                    ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(v) => println!(
-                        " • Interface Version: {}",
-                        v,
-                    ),
+                    ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(v) => {
+                        println!(" • Interface Version: {}", v,)
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
### What

Output env interface version in inspect sub-command.

### Why

For debugging and inspecting contracts.

Close https://github.com/stellar/rs-stellar-contract-sdk/issues/142

### Known limitations

[TODO or N/A]
