### PR TITLE
Fix name of env meta when not provided

### DIFF
--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -49,7 +49,7 @@ impl Inspect {
                 }
             }
         } else {
-            println!("Contract Spec: None");
+            println!("Env Meta: None");
         }
         if let Some(spec) = vm.custom_section("contractspecv0") {
             println!("Contract Spec: {}", base64::encode(spec));


### PR DESCRIPTION
### What

Change name of env meta to Env Meta for the line that prints saying there is no env meta.

### Why

It's env meta.

### Known limitations

[TODO or N/A]
