### PR TITLE
Add help messages to options

### DIFF
--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -7,6 +7,7 @@ use stellar_contract_env_host::{
 
 #[derive(Parser, Debug)]
 pub struct Inspect {
+    /// WASM file containing contract
     #[clap(long, parse(from_os_str))]
     file: std::path::PathBuf,
 }

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -17,16 +17,20 @@ use crate::strval::{self, StrValError};
 
 #[derive(Parser, Debug)]
 pub struct Invoke {
+    /// WASM file containing contract
     #[clap(long, parse(from_os_str))]
     file: std::path::PathBuf,
+    /// File to read and write ledger
     #[clap(long, parse(from_os_str), default_value("ledger.json"))]
     snapshot_file: std::path::PathBuf,
-    #[clap(long = "cost")]
     /// Output the cost of the invocation to stderr
+    #[clap(long = "cost")]
     cost: bool,
+    /// Name of function to invoke
     #[clap(long = "fn")]
     function: String,
-    #[clap(long = "arg", multiple_occurrences = true)]
+    /// Argument to pass to the contract function
+    #[clap(long = "arg", multiple = true)]
     args: Vec<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,9 @@ struct Root {
 
 #[derive(Subcommand, Debug)]
 enum Cmd {
+    /// Inspect a WASM file listing contract functions, meta, etc
     Inspect(Inspect),
+    /// Invoke a contract function in a WASM file
     Invoke(Invoke),
 }
 


### PR DESCRIPTION
### What

Add help messages to options.

### Why

To make it possible for new users to understand what the different CLI options do.

Close https://github.com/stellar/stellar-contract-cli/issues/34

### Known limitations

[TODO or N/A]
