### PR TITLE
Allow the option use the call and create contract host functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ version = "0.0.0"
 dependencies = [
  "base64",
  "clap",
+ "hex",
  "serde_json",
  "stellar-contract-env-host",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ clap = { version = "3.1.18", features = ["derive", "env"] }
 base64 = "0.13.0"
 thiserror = "1.0.31"
 serde_json = "1.0.82"
+hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ All values passed to `--arg` are the JSON representation of SCVals.
 ### Directly invoking a function in a user specified WASM contract
 
 ```
-stellar-contract-cli invoke --file <WASMFILE> vm-fn --fn <FUNCNAME> --arg '{"i32":32}' --arg '{"i32":4}'
+stellar-contract-cli invoke --file <WASMFILE> --fn <FUNCNAME> --arg '{"i32":32}' --arg '{"i32":4}'
 ```
 
 Example using the [example_add_i32](https://github.com/stellar/rs-stellar-contract-sdk/tree/main/examples/add_i32) contract:

--- a/README.md
+++ b/README.md
@@ -12,32 +12,31 @@ cargo install stellar-contract-cli --git https://github.com/stellar/stellar-cont
 
 All values passed to `--arg` are the JSON representation of SCVals.
 
-### Directly invoking a function in a user specified WASM contract
+### Creating a contract and invoking a function
+Note that this will also put the WASM contract in storage.
 
 ```
-stellar-contract-cli invoke --file <WASMFILE> --fn <FUNCNAME> --arg '{"i32":32}' --arg '{"i32":4}'
+stellar-contract-cli invoke --id <HEX_CONTRACTID> --file <WASMFILE> --fn <FUNCNAME> --arg '{"i32":32}' --arg '{"i32":4}'
 ```
 
 Example using the [example_add_i32](https://github.com/stellar/rs-stellar-contract-sdk/tree/main/examples/add_i32) contract:
 
 ```
-$ stellar-contract-cli invoke --file example_add_i32.wasm --fn add --arg '{"i32":32}' --arg '{"i32":4}'
+$ stellar-contract-cli invoke --id 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c --file example_add_i32.wasm --fn add --arg '{"i32":32}' --arg '{"i32":4}'
 
 {
   "i32": 36
 }
 ```
 
-### Creating and invoking a contract in storage
-
-#### Creating a contract
+### Creating a contract
 
 ```
 Example:
 stellar-contract-cli deploy --id 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c --file example_add_i32.wasm
 ```
 
-#### Invoking an existing contract
+### Invoking a contract in storage
 
 ```
 stellar-contract-cli invoke --fn add --id <HEX_CONTRACTID>  --arg '{"i32":32}' --arg '{"i32":4}'

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ cargo install stellar-contract-cli --git https://github.com/stellar/stellar-cont
 
 ## Usage
 
+### Directly invoking a function in auser specified WASM contract
+
 ```
-stellar-contract-cli invoke --file <WASMFILE> --fn <FUNCNAME> --arg i32:1 --arg i32:2
+stellar-contract-cli invoke --file <WASMFILE> vm-fn --fn <FUNCNAME> --arg i32:1 --arg i32:2
 ```
 
 Example using the [example_add_i32](https://github.com/stellar/rs-stellar-contract-sdk/tree/main/examples/add_i32) contract:
@@ -19,4 +21,24 @@ Example using the [example_add_i32](https://github.com/stellar/rs-stellar-contra
 ```
 $ stellar-contract-cli invoke --file example_add_i32.wasm --fn add --arg i32:1 --arg i32:2
 i32:3
+```
+
+### Calling a host function
+
+For both options below, the file should contain a JSON representation of the `SCVec` xdr object, which is passed directly to `invoke_function` in the host. The order of the items in the `SCVec` is specified below.
+
+#### Creating a contract
+
+```
+// args = SCVec(contractCode, salt, ed25519, signature)
+stellar-contract-cli invoke --file <JSONARGS> create-contract
+```
+
+The input file is the 
+
+#### Invoking an existing contract
+
+```
+// args = SCVec(contractID, functionName, args...)
+stellar-contract-cli invoke --file <JSONARGS> call
 ```

--- a/README.md
+++ b/README.md
@@ -10,35 +10,41 @@ cargo install stellar-contract-cli --git https://github.com/stellar/stellar-cont
 
 ## Usage
 
-### Directly invoking a function in auser specified WASM contract
+All values passed to `--arg` are the JSON representation of SCVals.
+
+### Directly invoking a function in a user specified WASM contract
 
 ```
-stellar-contract-cli invoke --file <WASMFILE> vm-fn --fn <FUNCNAME> --arg i32:1 --arg i32:2
+stellar-contract-cli invoke --file <WASMFILE> vm-fn --fn <FUNCNAME> --arg '{"i32":32}' --arg '{"i32":4}'
 ```
 
 Example using the [example_add_i32](https://github.com/stellar/rs-stellar-contract-sdk/tree/main/examples/add_i32) contract:
 
 ```
-$ stellar-contract-cli invoke --file example_add_i32.wasm --fn add --arg i32:1 --arg i32:2
-i32:3
+$ stellar-contract-cli invoke --file example_add_i32.wasm --fn add --arg '{"i32":32}' --arg '{"i32":4}'
+
+{
+  "i32": 36
+}
 ```
 
-### Calling a host function
-
-For both options below, the file should contain a JSON representation of the `SCVec` xdr object, which is passed directly to `invoke_function` in the host. The order of the items in the `SCVec` is specified below.
+### Creating and invoking a contract in storage
 
 #### Creating a contract
 
 ```
-// args = SCVec(contractCode, salt, ed25519, signature)
-stellar-contract-cli invoke --file <JSONARGS> create-contract
+Example:
+stellar-contract-cli deploy --id 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c --file example_add_i32.wasm
 ```
-
-The input file is the 
 
 #### Invoking an existing contract
 
 ```
-// args = SCVec(contractID, functionName, args...)
-stellar-contract-cli invoke --file <JSONARGS> call
+stellar-contract-cli invoke --fn add --id <HEX_CONTRACTID>  --arg '{"i32":32}' --arg '{"i32":4}'
+
+Example:
+stellar-contract-cli invoke --fn add --id 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c --arg '{"i32":32}' --arg '{"i32":4}'
+
+
+stellar-contract-cli invoke --fn put --id 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c --arg '{"symbol": [69, 50, 53, 49, 57]}' --arg '{"symbol": [69, 50, 53]}'
 ```

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -1,0 +1,66 @@
+use std::{fmt::Debug, fs, io};
+
+use clap::Parser;
+use stellar_contract_env_host::xdr::{
+    ContractDataEntry, Error as XdrError, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerKey,
+    LedgerKeyContractData, ScObject, ScStatic, ScVal,
+};
+
+use hex::{FromHex, FromHexError};
+
+use crate::snapshot;
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    #[clap(long = "id")]
+    /// Contract ID in Hexadecimal
+    contract_id: String,
+    /// File that contains a WASM contract
+    #[clap(long, parse(from_os_str))]
+    file: std::path::PathBuf,
+    /// File to read and write ledger
+    #[clap(long, parse(from_os_str), default_value("ledger.json"))]
+    snapshot_file: std::path::PathBuf,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("io")]
+    Io(#[from] io::Error),
+    #[error("xdr")]
+    Xdr(#[from] XdrError),
+    #[error("snapshot")]
+    Snapshot(#[from] snapshot::Error),
+    #[error("hex")]
+    FromHex(#[from] FromHexError),
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result<(), Error> {
+        let contract_id: [u8; 32] = FromHex::from_hex(&self.contract_id)?;
+        let contract = fs::read(&self.file).unwrap();
+
+        let key = LedgerKey::ContractData(LedgerKeyContractData {
+            contract_id: contract_id.into(),
+            key: ScVal::Static(ScStatic::LedgerKeyContractCodeWasm),
+        });
+
+        let data = LedgerEntryData::ContractData(ContractDataEntry {
+            contract_id: contract_id.into(),
+            key: ScVal::Static(ScStatic::LedgerKeyContractCodeWasm),
+            val: ScVal::Object(Some(ScObject::Binary(contract.try_into()?))),
+        });
+
+        let entry = LedgerEntry {
+            last_modified_ledger_seq: 0,
+            data,
+            ext: LedgerEntryExt::V0,
+        };
+
+        let mut ledger_entries = snapshot::read(&self.snapshot_file)?;
+        ledger_entries.insert(key, entry);
+
+        snapshot::commit(ledger_entries, None, &self.snapshot_file)?;
+        Ok(())
+    }
+}

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -1,57 +1,41 @@
-use std::{
-    fmt::Debug,
-    fs::{self, File},
-    io,
-    rc::Rc,
-};
+use std::{fmt::Debug, fs, io, rc::Rc};
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use stellar_contract_env_host::{
     budget::CostType,
     storage::Storage,
-    xdr::{Error as XdrError, HostFunction, ScVal, ScVec},
+    xdr::{Error as XdrError, HostFunction, ScObject, ScVal, ScVec},
     Host, HostError, Vm,
 };
 
-use crate::strval::{self, StrValError};
+use hex::{FromHex, FromHexError};
 
 use crate::snapshot;
 
-#[derive(Subcommand, Debug)]
-enum Commands {
-    Call,
-    VmFn {
-        /// Name of function to invoke
-        #[clap(long = "fn")]
-        function: String,
-        /// Argument to pass to the contract function
-        #[clap(long = "arg", value_name = "arg", multiple = true)]
-        args: Vec<String>,
-    },
-}
-
 #[derive(Parser, Debug)]
 pub struct Cmd {
-    //TODO: move this into each subcommand instead?
-    /// If command == vm-fn, then this is the WASM file containing contract, otherwise, it's a JSON SCVec
-    #[clap(long, parse(from_os_str))]
-    file: std::path::PathBuf,
+    /// Name of function to invoke
+    #[clap(long = "fn")]
+    function: String,
     /// File to read and write ledger
     #[clap(long, parse(from_os_str), default_value("ledger.json"))]
     snapshot_file: std::path::PathBuf,
     /// Output the cost of the invocation to stderr
     #[clap(long = "cost")]
     cost: bool,
-    #[clap(subcommand)]
-    command: Commands,
+    #[clap(long, parse(from_os_str))]
+    file: Option<std::path::PathBuf>,
+    #[clap(long = "id", conflicts_with("file"))]
+    contract_id: Option<String>,
+    /// Argument to pass to the contract function
+    #[clap(long = "arg", value_name = "arg", multiple = true)]
+    args: Vec<String>,
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("io")]
     Io(#[from] io::Error),
-    #[error("strval")]
-    StrVal(#[from] StrValError),
     #[error("xdr")]
     Xdr(#[from] XdrError),
     #[error("host")]
@@ -60,6 +44,8 @@ pub enum Error {
     Snapshot(#[from] snapshot::Error),
     #[error("serde")]
     Serde(#[from] serde_json::Error),
+    #[error("hex")]
+    FromHex(#[from] FromHexError),
 }
 
 impl Cmd {
@@ -74,25 +60,32 @@ impl Cmd {
 
         let mut h = Host::with_storage(storage);
 
-        match &self.command {
-            Commands::Call => {
-                let mut file = File::open(&self.file).unwrap();
-                let args: ScVec = serde_json::from_reader(&mut file)?;
-                let _res = h.invoke_function(HostFunction::Call, args)?;
-            }
-            Commands::VmFn { function, args } => {
-                let contents = fs::read(&self.file).unwrap();
-                let args = args
-                    .iter()
-                    .map(|a| strval::from_string(&h, a))
-                    .collect::<Result<Vec<ScVal>, StrValError>>()?;
+        let args = &self
+            .args
+            .iter()
+            .map(|a| serde_json::from_str(a))
+            .collect::<Result<Vec<ScVal>, serde_json::Error>>()?;
 
-                //TODO: contractID should be user specified
-                let vm = Vm::new(&h, [0; 32].into(), &contents).unwrap();
-                let res = vm.invoke_function(&h, function, &ScVec(args.try_into()?))?;
-                let res_str = strval::to_string(&h, res);
-                println!("{}", res_str);
-            }
+        if let Some(f) = &self.file {
+            let contents = fs::read(f).unwrap();
+
+            //TODO: contractID should be user specified
+            let vm = Vm::new(&h, [0; 32].into(), &contents).unwrap();
+            let res = vm.invoke_function(&h, &self.function, &ScVec(args.try_into()?))?;
+            println!("{}", serde_json::to_string_pretty(&res)?);
+        } else if let Some(id) = &self.contract_id {
+            let contract_id: [u8; 32] = FromHex::from_hex(id)?;
+
+            let mut complete_args = vec![
+                ScVal::Object(Some(ScObject::Binary(contract_id.try_into()?))),
+                ScVal::Symbol((&self.function).try_into()?),
+            ];
+            complete_args.extend_from_slice(args.as_slice());
+
+            let res = h.invoke_function(HostFunction::Call, complete_args.try_into()?)?;
+            println!("{}", serde_json::to_string_pretty(&res)?);
+        } else {
+            panic!("exactly one of file or contract_id need to be specified");
         }
 
         if self.cost {

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -15,6 +15,8 @@ use stellar_contract_env_host::{
 
 use crate::strval::{self, StrValError};
 
+use crate::snapshot;
+
 #[derive(Subcommand, Debug)]
 enum Commands {
     Call,
@@ -55,78 +57,10 @@ pub enum Error {
     Xdr(#[from] XdrError),
     #[error("host")]
     Host(#[from] HostError),
+    #[error("snapshot")]
+    Snapshot(#[from] snapshot::Error),
     #[error("serde")]
     Serde(#[from] serde_json::Error),
-}
-
-pub mod snapshot {
-    use std::fs::File;
-
-    use super::{Error, HostError};
-    use stellar_contract_env_host::{
-        im_rc::OrdMap,
-        storage::SnapshotSource,
-        xdr::{LedgerEntry, LedgerKey, VecM},
-    };
-
-    pub struct Snap {
-        pub ledger_entries: OrdMap<LedgerKey, LedgerEntry>,
-    }
-
-    impl SnapshotSource for Snap {
-        fn get(&self, key: &LedgerKey) -> Result<LedgerEntry, HostError> {
-            match self.ledger_entries.get(key) {
-                Some(v) => Ok(v.clone()),
-                None => Err(HostError::General("missing entry")),
-            }
-        }
-        fn has(&self, key: &LedgerKey) -> Result<bool, HostError> {
-            Ok(self.ledger_entries.contains_key(key))
-        }
-    }
-
-    // snapshot_file format is the default serde JSON representation of VecM<(LedgerKey, LedgerEntry)>
-    pub fn read(input_file: &std::path::PathBuf) -> Result<OrdMap<LedgerKey, LedgerEntry>, Error> {
-        let mut res = OrdMap::new();
-
-        let mut file = match File::open(input_file) {
-            Ok(f) => f,
-            Err(e) => {
-                //File doesn't exist, so treat this as an empty database and the file will be created later
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    return Ok(res);
-                }
-                return Err(Error::Io(e));
-            }
-        };
-
-        let state: VecM<(LedgerKey, LedgerEntry)> = serde_json::from_reader(&mut file)?;
-        res = state.iter().cloned().collect();
-
-        Ok(res)
-    }
-
-    pub fn commit(
-        mut new_state: OrdMap<LedgerKey, LedgerEntry>,
-        storage_map: &OrdMap<LedgerKey, Option<LedgerEntry>>,
-        output_file: &std::path::PathBuf,
-    ) -> Result<(), Error> {
-        //Need to start off with the existing snapshot (new_state) since it's possible the storage_map did not touch every existing entry
-        let file = File::create(output_file)?;
-        for (lk, ole) in storage_map {
-            if let Some(le) = ole {
-                new_state.insert(lk.clone(), le.clone());
-            } else {
-                new_state.remove(lk);
-            }
-        }
-
-        let vec_new_state: VecM<(LedgerKey, LedgerEntry)> =
-            new_state.into_iter().collect::<Vec<_>>().try_into()?;
-        serde_json::to_writer(&file, &vec_new_state)?;
-
-        Ok(())
-    }
 }
 
 impl Cmd {

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -20,7 +20,6 @@ use crate::snapshot;
 #[derive(Subcommand, Debug)]
 enum Commands {
     Call,
-    CreateContract,
     VmFn {
         /// Name of function to invoke
         #[clap(long = "fn")]
@@ -81,11 +80,6 @@ impl Cmd {
                 let args: ScVec = serde_json::from_reader(&mut file)?;
                 let _res = h.invoke_function(HostFunction::Call, args)?;
             }
-            Commands::CreateContract => {
-                let mut file = File::open(&self.file).unwrap();
-                let args: ScVec = serde_json::from_reader(&mut file)?;
-                let _res = h.invoke_function(HostFunction::CreateContract, args)?;
-            }
             Commands::VmFn { function, args } => {
                 let contents = fs::read(&self.file).unwrap();
                 let args = args
@@ -115,7 +109,7 @@ impl Cmd {
             .recover_storage()
             .map_err(|_h| HostError::General("could not get storage from host"))?;
 
-        snapshot::commit(ledger_entries, &storage.map, &self.snapshot_file)?;
+        snapshot::commit(ledger_entries, Some(&storage.map), &self.snapshot_file)?;
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use clap::{AppSettings, Parser, Subcommand};
 use thiserror::Error;
 
-mod strval;
-
 mod deploy;
 mod inspect;
 mod invoke;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod strval;
 
 mod inspect;
 mod invoke;
+mod snapshot;
 mod version;
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 mod strval;
 
+mod deploy;
 mod inspect;
 mod invoke;
 mod snapshot;
@@ -22,6 +23,8 @@ enum Cmd {
     Invoke(invoke::Cmd),
     /// Inspect a WASM file listing contract functions, meta, etc
     Inspect(inspect::Cmd),
+    /// Writes a contractID and WASM contract directly to storage
+    Deploy(deploy::Cmd),
     /// Print version information
     Version(version::Cmd),
 }
@@ -32,12 +35,15 @@ enum CmdError {
     Inspect(#[from] inspect::Error),
     #[error("invoke")]
     Invoke(#[from] invoke::Error),
+    #[error("deploy")]
+    Deploy(#[from] deploy::Error),
 }
 
 fn run(cmd: Cmd) -> Result<(), CmdError> {
     match cmd {
         Cmd::Inspect(inspect) => inspect.run()?,
         Cmd::Invoke(invoke) => invoke.run()?,
+        Cmd::Deploy(deploy) => deploy.run()?,
         Cmd::Version(version) => version.run(),
     };
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod deploy;
 mod inspect;
 mod invoke;
 mod snapshot;
+mod utils;
 mod version;
 
 #[derive(Parser, Debug)]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,79 @@
+use std::{fs::File, io};
+
+use stellar_contract_env_host::{
+    im_rc::OrdMap,
+    storage::SnapshotSource,
+    xdr::{Error as XdrError, LedgerEntry, LedgerKey, VecM},
+    HostError,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("io")]
+    Io(#[from] io::Error),
+    #[error("xdr")]
+    Xdr(#[from] XdrError),
+    #[error("host")]
+    Host(#[from] HostError),
+    #[error("serde")]
+    Serde(#[from] serde_json::Error),
+}
+
+pub struct Snap {
+    pub ledger_entries: OrdMap<LedgerKey, LedgerEntry>,
+}
+
+impl SnapshotSource for Snap {
+    fn get(&self, key: &LedgerKey) -> Result<LedgerEntry, HostError> {
+        match self.ledger_entries.get(key) {
+            Some(v) => Ok(v.clone()),
+            None => Err(HostError::General("missing entry")),
+        }
+    }
+    fn has(&self, key: &LedgerKey) -> Result<bool, HostError> {
+        Ok(self.ledger_entries.contains_key(key))
+    }
+}
+
+// snapshot_file format is the default serde JSON representation of VecM<(LedgerKey, LedgerEntry)>
+pub fn read(input_file: &std::path::PathBuf) -> Result<OrdMap<LedgerKey, LedgerEntry>, Error> {
+    let mut res = OrdMap::new();
+
+    let mut file = match File::open(input_file) {
+        Ok(f) => f,
+        Err(e) => {
+            //File doesn't exist, so treat this as an empty database and the file will be created later
+            if e.kind() == std::io::ErrorKind::NotFound {
+                return Ok(res);
+            }
+            return Err(Error::Io(e));
+        }
+    };
+
+    let state: VecM<(LedgerKey, LedgerEntry)> = serde_json::from_reader(&mut file)?;
+    res = state.iter().cloned().collect();
+
+    Ok(res)
+}
+
+pub fn commit(
+    mut new_state: OrdMap<LedgerKey, LedgerEntry>,
+    storage_map: &OrdMap<LedgerKey, Option<LedgerEntry>>,
+    output_file: &std::path::PathBuf,
+) -> Result<(), Error> {
+    //Need to start off with the existing snapshot (new_state) since it's possible the storage_map did not touch every existing entry
+    let file = File::create(output_file)?;
+    for (lk, ole) in storage_map {
+        if let Some(le) = ole {
+            new_state.insert(lk.clone(), le.clone());
+        } else {
+            new_state.remove(lk);
+        }
+    }
+
+    let vec_new_state: VecM<(LedgerKey, LedgerEntry)> =
+        new_state.into_iter().collect::<Vec<_>>().try_into()?;
+    serde_json::to_writer(&file, &vec_new_state)?;
+
+    Ok(())
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -58,16 +58,18 @@ pub fn read(input_file: &std::path::PathBuf) -> Result<OrdMap<LedgerKey, LedgerE
 
 pub fn commit(
     mut new_state: OrdMap<LedgerKey, LedgerEntry>,
-    storage_map: &OrdMap<LedgerKey, Option<LedgerEntry>>,
+    storage_map: Option<&OrdMap<LedgerKey, Option<LedgerEntry>>>,
     output_file: &std::path::PathBuf,
 ) -> Result<(), Error> {
     //Need to start off with the existing snapshot (new_state) since it's possible the storage_map did not touch every existing entry
     let file = File::create(output_file)?;
-    for (lk, ole) in storage_map {
-        if let Some(le) = ole {
-            new_state.insert(lk.clone(), le.clone());
-        } else {
-            new_state.remove(lk);
+    if let Some(s) = storage_map {
+        for (lk, ole) in s {
+            if let Some(le) = ole {
+                new_state.insert(lk.clone(), le.clone());
+            } else {
+                new_state.remove(lk);
+            }
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,33 @@
+use stellar_contract_env_host::{
+    im_rc::OrdMap,
+    xdr::{
+        ContractDataEntry, Error as XdrError, LedgerEntry, LedgerEntryData, LedgerEntryExt,
+        LedgerKey, LedgerKeyContractData, ScObject, ScStatic, ScVal,
+    },
+};
+
+pub fn add_contract_to_ledger_entries(
+    entries: &mut OrdMap<LedgerKey, LedgerEntry>,
+    contract_id: [u8; 32],
+    contract: Vec<u8>,
+) -> Result<(), XdrError> {
+    let key = LedgerKey::ContractData(LedgerKeyContractData {
+        contract_id: contract_id.into(),
+        key: ScVal::Static(ScStatic::LedgerKeyContractCodeWasm),
+    });
+
+    let data = LedgerEntryData::ContractData(ContractDataEntry {
+        contract_id: contract_id.into(),
+        key: ScVal::Static(ScStatic::LedgerKeyContractCodeWasm),
+        val: ScVal::Object(Some(ScObject::Binary(contract.try_into()?))),
+    });
+
+    let entry = LedgerEntry {
+        last_modified_ledger_seq: 0,
+        data,
+        ext: LedgerEntryExt::V0,
+    };
+
+    entries.insert(key, entry);
+    Ok(())
+}


### PR DESCRIPTION
Resolves #29 and related to #22.

The two new commands take a JSON SCVec as an argument. I haven't updated how arguments are passed to the existing command that invokes WASM directly, but wanted to get input on this change before moving forward.

The user experience also isn't great, but I think we can make some improvements. The user needs to construct the JSON, which isn't really feasible by hand. For example, I tested this by using a rust test case and printed out the arguments that I wanted.